### PR TITLE
Keep track of discovered players do avoid duplicate notifications

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -35,11 +35,13 @@ namespace OpenRA.Mods.Common.Traits
 		int ticksBeforeNextNotification;
 		HashSet<uint> lastKnownActorIds;
 		HashSet<uint> visibleActorIds;
+		HashSet<Player> discoveredPlayers;
 		HashSet<string> playedNotifications;
 
 		public EnemyWatcher(EnemyWatcherInfo info)
 		{
 			lastKnownActorIds = new HashSet<uint>();
+			discoveredPlayers = new HashSet<Player>();
 			this.info = info;
 			rescanInterval = info.ScanInterval;
 			ticksBeforeNextNotification = info.NotificationInterval;
@@ -88,9 +90,15 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var trait in actor.Actor.TraitsImplementing<INotifyDiscovered>())
 					trait.OnDiscovered(actor.Actor, self.Owner, !notificationPlayed);
 
-				// Notify the actor's owner that he's been discovered
-				foreach (var trait in actor.Actor.Owner.PlayerActor.TraitsImplementing<INotifyDiscovered>())
-					trait.OnDiscovered(actor.Actor.Owner.PlayerActor, self.Owner, false);
+				var discoveredPlayer = actor.Actor.Owner;
+				if (!discoveredPlayers.Contains(discoveredPlayer))
+				{
+					// Notify the actor's owner that he's been discovered
+					foreach (var trait in discoveredPlayer.PlayerActor.TraitsImplementing<INotifyDiscovered>())
+						trait.OnDiscovered(actor.Actor, self.Owner, false);
+
+					discoveredPlayers.Add(discoveredPlayer);
+				}
 
 				// We have already played this type of notification
 				if (notificationPlayed)


### PR DESCRIPTION
Not sure if you want this, but I guess it makes sense.

I also changed the actor from the that is used in the callback from the PlayerActor to the discovered actor. A player then gets to know which unit gave himself away.  The PlayerActor itself is pretty useless otherwise. From c#, you can get to it from the other actor as well, and in Lua you can't do anything with it.

This commit should probably be squashed into one of your others.
